### PR TITLE
Specify required version of tslib ^2.0.0

### DIFF
--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -67,6 +67,7 @@
     "worker-loader": "^3.0.7"
   },
   "dependencies": {
-    "@antv/util": "^2.0.13"
+    "@antv/util": "^2.0.13",
+    "tslib": "^2.0.0"
   }
 }


### PR DESCRIPTION
The version + features of typescript used to compile this lib means that tslib needs to be at version 2.0.0 minimum.

Because `antvis/algorithm` doesn't specify an explicit version, it is not guaranteed that developers receive the necessary version.
This causes the following error at import time:
```
./node_modules/@antv/algorithm/es/gaddi.js
Attempted import error: '__spreadArray' is not exported from 'tslib'.
```

You can see here all the other projects updating their tslib dependencies similarly in the references to this PR: https://github.com/microsoft/tslib/pull/133

This relates to
https://github.com/antvis/G6/issues/2702
and
https://github.com/antvis/G6/issues/2713
it is likely necessary, but may not be sufficient, to fix those reported issues. There could be other `antvis` packages with the same issue.